### PR TITLE
fix: availability of using xiaozhi-esp32-server as backend

### DIFF
--- a/examples/xiaozhi/xiaozhi/services/protocols/websocket_protocol.py
+++ b/examples/xiaozhi/xiaozhi/services/protocols/websocket_protocol.py
@@ -201,7 +201,7 @@ class WebsocketProtocol(Protocol):
             if self.websocket and get_xiaozhi().device_state == DeviceState.IDLE:
                 try:
                     await self.send_text(
-                        json.dumps({"session_id": "", "type": "abort"})
+                        json.dumps({"session_id": "", "type": "ping"})
                     )
                 except Exception:
                     # 发送心跳失败，重新连接


### PR DESCRIPTION
Fixes #35.

This project uses a type=abort message as a heartbeat detector. However, the xiaozhi-esp32-server project's WebSocket server triggers an abort action upon receiving a type=abort message, causing confusing behavior. I replaced it with a type=ping message for the heartbeat detector, a `type=ping` message is meanless, so it won't harm any functionality.