### PR TITLE
[README] 添加了基于本项目 xiaozhi 示例的增强 config.py 的项目 oxa-server 的相关链接

### DIFF
--- a/examples/xiaozhi/README.md
+++ b/examples/xiaozhi/README.md
@@ -160,6 +160,10 @@ PS：如果还是不行，建议更换其他更易识别的唤醒词。
 
 由于 ASR 相关模型文件体积较大，并未直接提交在 git 仓库中，你可以在 release 中下载 [VAD + KWS 相关模型](https://github.com/idootop/open-xiaoai/releases/tag/vad-kws-models)，然后解压到 `xiaozhi/models` 路径下即可。
 
+## 相关项目
+
+- [oxa-server](https://github.com/pu-007/oxa-server): 提供了更强大易用的 config.py 的配置方式
+
 ## 鸣谢
 
 该演示使用的 Python 版小智 AI 客户端基于 [py-xiaozhi](https://github.com/Huang-junsen/py-xiaozhi) 项目，特此鸣谢。


### PR DESCRIPTION
这个项目目前初步完善了，可以用一个 dict 很方便的设置免唤醒词命令，还能够自定义函数、自动安装依赖，相当于一个增强版本的 config.py。放在了 xiaozhi example 的 README 里面，方便有需要的人使用。

配置示例如下：

```python
KWS_WAKEUP = ["小智小智"]


async def wake_up_computer(_):
    """
    发送网络唤醒 (Wake-on-LAN) 魔法包来启动电脑。
    """
    _ensure_dependencies(["wakeonlan"])

    computer_mac = "08BFB8A67CE2"
    subnet_broadcast_ip = "192.168.100.255"

    from wakeonlan import send_magic_packet

    await asyncio.to_thread(send_magic_packet,
                            computer_mac,
                            ip_address=subnet_broadcast_ip)


COMMAND_MAP: Dict[str, List[str | Callable | Awaitable]] = {
    # 小爱原生指令
    "切换电视": ["打开电视"],
    "请开空调": ["打开空调"],
    # 组合指令
    "点亮外面": ["打开台灯", "打开副灯"],
    "熄灭外面": ["关闭台灯", "关闭副灯"],
    "关灯空调": ["关闭主灯", "关闭台灯", "关闭副灯", "关闭空调"],
    "灯光全灭": ["关闭主灯", "关闭台灯", "关闭副灯"],
    "全部关闭": ["关闭空调", "关闭风扇", "关闭主灯", "关闭电视", "关闭我的电脑", "关闭台灯", "关闭副灯"],

    # PC 控制 & 特殊指令 （ 关联项目：cut_in_xiaoai，使用巴法云模拟设备实现控制电脑等终端，待完善优化结合方式）
    "请开电脑": [wake_up_computer],
    "切换屏幕": ["我的电脑设置为三"],
    "请关电脑": ["关闭我的电脑"],
    "重启电脑": ["我的电脑设置为一"],
    "测试电脑": ["我的电脑设置为七"],  # 按下空格

    # 混合指令
    "联合启动": [wake_up_computer, "打开电视"],
    "联合关闭": ["关闭我的电脑", "关闭电视"],
}
```