### PR TITLE
Update sed command delimiter in patch.sh

### DIFF
--- a/packages/client-patch/src/patch.sh
+++ b/packages/client-patch/src/patch.sh
@@ -22,7 +22,7 @@ apply_patches() {
                     # 创建临时文件用于占位符替换
                     local temp_patch=$(mktemp)
                     # 将补丁文件中的 {SSH_PASSWORD} 替换为 PASSWORD
-                    sed "s/{SSH_PASSWORD}/$PASSWORD/g" "$file" > "$temp_patch"
+                    sed "s|{SSH_PASSWORD}|$PASSWORD|g" "$file" > "$temp_patch"
                     # 应用替换后的补丁
                     patch -p1 < "$temp_patch"
                     # 清理临时文件


### PR DESCRIPTION
`$PASSWORD`通过`PASSWORD=$(openssl passwd -1 -salt "open-xiaoai" "$PASSWORD")`生成，而`openssl passwd -1`生成的是 MD5 crypt 格式的哈希密码。
在某些特定的情况下，该哈希结果会含有'/'，导致破坏sed中的`s///`语法。该哈希算法的取值不含`|`，使用`|`替代'/'作为分隔符。